### PR TITLE
refactor: use new testcontainers version

### DIFF
--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3" />
-    <PackageReference Include="Testcontainers" Version="2.1.0" />
+    <PackageReference Include="Testcontainers" Version="2.2.0-beta.3311860540" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/tests/common/IntegrationTestFactory.cs
+++ b/tests/common/IntegrationTestFactory.cs
@@ -16,8 +16,7 @@ public class IntegrationTestFactory<TProgram, TDbContext> : WebApplicationFactor
     public IntegrationTestFactory()
     {
         _container = new TestcontainersBuilder<MySqlTestcontainer>()
-            .WithDatabase(new MySqlTestcontainerConfiguration { Database = "datadonation", Username = "test123", Password = "example"})
-            .WithEnvironment("MYSQL_ROOT_PASSWORD", "example")
+            .WithDatabase(new MySqlTestcontainerConfiguration { Database = "datadonation", Username = "root", Password = "example" })
             .WithImage("mysql:8.0.29")
             .WithCleanUp(true)
             .Build();
@@ -40,7 +39,7 @@ public class IntegrationTestFactory<TProgram, TDbContext> : WebApplicationFactor
                 }
             }
 
-            var connectionString = _container.ConnectionString.Replace("test123", "root") + ";OldGuids=true" ;
+            var connectionString = _container.ConnectionString + ";OldGuids=true";
 
             var serverVersion =
                 new MySqlServerVersion(ServerVersion.AutoDetect(connectionString));


### PR DESCRIPTION
do not use the workaround anymore

<a href="https://gitpod.io/#https://github.com/OSPRS/DataDonation/pull/3"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

